### PR TITLE
Rename kafka to kafka2 (fixes #4)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,4 +21,7 @@ This CHANGELOG follows the format located [here](https://github.com/sensu-plugin
 - removing EOL versions of ruby
 - patching for any known CVEs
 
+### Fixed
+- renamed kafka to kafka2 to fix [#4](https://github.com/sensu-plugins/sensu-plugins-kafka2/issues/4) (@maoe)
+
 [Unreleased]: https://github.com/sensu-plugins/sensu-plugins-kafka/compare/d4eebcfed091899571e21c0e433cceb3e386d2c7...HEAD

--- a/bin/check-kafka-ping.rb
+++ b/bin/check-kafka-ping.rb
@@ -28,10 +28,10 @@
 require 'sensu-plugin/check/cli'
 require 'rest-client'
 require 'json'
-require 'sensu-plugins-kafka'
+require 'sensu-plugins-kafka2'
 
 class CheckKafkaPing < Sensu::Plugin::Check::CLI
-  include CommonKafka
+  include CommonKafka2
 
   option :endpoint,
          short: '-p ENDPOINT',

--- a/bin/metrics-kafka-http.rb
+++ b/bin/metrics-kafka-http.rb
@@ -29,10 +29,10 @@
 require 'sensu-plugin/metric/cli'
 require 'rest-client'
 require 'json'
-require 'sensu-plugins-kafka'
+require 'sensu-plugins-kafka2'
 
 class MetricsKafkaHttp < Sensu::Plugin::Metric::CLI::Generic
-  include CommonKafka
+  include CommonKafka2
   option :endpoint,
          short: '-p ENDPOINT',
          long: '--endpoint ENDPOINT',


### PR DESCRIPTION
## Pull Request Checklist

This PR is a bug fix for #4.

#### General

- [x] Update Changelog following the conventions laid out [here](https://github.com/sensu-plugins/community/blob/master/HOW_WE_CHANGELOG.md)

- [ ] Update README with any necessary configuration snippets: N/A

- [ ] Binstubs are created if needed: N/A

- [x] RuboCop passes

- [ ] Existing tests pass

#### Purpose

check-kafka-ping and metrics-kafka-http are broken because they still `require 'sense-plugins-kafka' and `include CommonKafka` although the file/module were renamed to `sensu-plugins-kafka2` and `CommonKafka2` respectively. This PR fixes it.

#### Known Compatibility Issues

No known issues.